### PR TITLE
Enable OSI-equivalent license identifiers as SPDX

### DIFF
--- a/qc_lic_licensee/report2sqaaas_plugins_licensee/main.py
+++ b/qc_lic_licensee/report2sqaaas_plugins_licensee/main.py
@@ -126,7 +126,7 @@ class LicenseeValidator(sqaaas_utils.BaseValidator):
                     else:
                         license_osi = None
                         for license_data in license_list:
-                            for identifiers in  license_data['identifiers']:
+                            for identifiers in license_data['identifiers']:
                                 if identifiers['identifier'] == license_type:
                                     license_osi = license_data['id']
                                     break

--- a/qc_lic_licensee/report2sqaaas_plugins_licensee/main.py
+++ b/qc_lic_licensee/report2sqaaas_plugins_licensee/main.py
@@ -110,9 +110,7 @@ class LicenseeValidator(sqaaas_utils.BaseValidator):
             OSI_ENDPOINTS = [
                 'https://api.opensource.org/licenses/%s' % _endpoint,
                 'https://api.opensource.org.s3.amazonaws.com/licenses/'
-                'licenses.json',
-                'https://raw.githubusercontent.com/spdx/'
-                'license-list-data/master/json/licenses.json'
+                'licenses.json'
             ]
             osi_request_succeed = False
             for osi_endpoint in OSI_ENDPOINTS:
@@ -124,6 +122,15 @@ class LicenseeValidator(sqaaas_utils.BaseValidator):
                         license_data['id'] for license_data in license_list
                     ]
                     if license_type in licenses:
+                        license_osi = license_type
+                    else:
+                        license_osi = None
+                        for license_data in license_list:
+                            for identifiers in  license_data['identifiers']:
+                                if identifiers['identifier'] == license_type:
+                                    license_osi = license_data['id']
+                                    break
+                    if license_osi in licenses:
                         subcriterion_valid = True
                         evidence = subcriterion_data['evidence']['success']
                     else:

--- a/qc_lic_licensee/report2sqaaas_plugins_licensee/main.py
+++ b/qc_lic_licensee/report2sqaaas_plugins_licensee/main.py
@@ -110,7 +110,9 @@ class LicenseeValidator(sqaaas_utils.BaseValidator):
             OSI_ENDPOINTS = [
                 'https://api.opensource.org/licenses/%s' % _endpoint,
                 'https://api.opensource.org.s3.amazonaws.com/licenses/'
-                'licenses.json'
+                'licenses.json',
+                'https://raw.githubusercontent.com/spdx/'
+                'license-list-data/master/json/licenses.json'
             ]
             osi_request_succeed = False
             for osi_endpoint in OSI_ENDPOINTS:


### PR DESCRIPTION
OSI licenses at https://api.opensource.org/licenses/ are indexed ("id" key) by very short names, but the equivalent names for other standards (as SPDX) are under a sublist called as "identifiers". For example:

```json
{"id":"BSD-3",
"identifiers":[
      {"identifier":"BSD-3-clause","scheme":"DEP5"},
      {"identifier":"BSD-3-Clause","scheme":"SPDX"},
      {"identifier":"License :: OSI Approved :: BSD License","scheme":"Trove"}
],
"links":[
      {"note":"Wikipedia Page","url":"https://en.wikipedia.org/wiki/BSD_licenses#3-clause"},
      {"note":"OSI Page","url":"https://opensource.org/licenses/BSD-3-Clause"}
],
"name":"BSD 3-Clause License",
"other_names":[
       {"name":"Revised BSD License","note":null},
       {"name":"Modified BSD License","note":null},
       {"name":"New BSD License","note":null}
],
"superseded_by":null,
"keywords":["osi-approved","popular","permissive"],
"text":[{"media_type":"text/html","title":"HTML","url":"https://opensource.org/licenses/BSD-3-Clause"}]
}
```

To properly recongnise these identifiers, this JSON should be proceseed for enabling their indexation. 

Thus, I make an addional test, searching for OSI equivalents:

```python
...
...
                    if license_type in licenses:
                        license_osi = license_type
                    else:
                        license_osi = None
                        for license_data in license_list:
                            for identifiers in  license_data['identifiers']:
                                if identifiers['identifier'] == license_type:
                                    license_osi = license_data['id']
                                    break
                    if license_osi in licenses:
                        subcriterion_valid = True
                        evidence = subcriterion_data['evidence']['success']
                    else:
...
...
```

Cheers.